### PR TITLE
Fix compatibility issues between 1.20.2 and 1.20.4

### DIFF
--- a/src/main/java/com/vulpeus/kyoyu/client/mixins/ClientboundCustomPayloadPacketMixin.java
+++ b/src/main/java/com/vulpeus/kyoyu/client/mixins/ClientboundCustomPayloadPacketMixin.java
@@ -1,6 +1,6 @@
 package com.vulpeus.kyoyu.client.mixins;
 
-//? if FABRIC && >=1.20.2 <1.20.5 {
+//? if client && >=1.20.2 <=1.20.4 {
 /*
 import com.vulpeus.kyoyu.Kyoyu;
 import com.vulpeus.kyoyu.net.KyoyuPacketPayload;

--- a/src/main/java/com/vulpeus/kyoyu/client/mixins/ClientboundCustomPayloadPacketMixin.java
+++ b/src/main/java/com/vulpeus/kyoyu/client/mixins/ClientboundCustomPayloadPacketMixin.java
@@ -1,0 +1,25 @@
+package com.vulpeus.kyoyu.client.mixins;
+
+//? if FABRIC && >=1.20.2 <1.20.5 {
+/*
+import com.vulpeus.kyoyu.Kyoyu;
+import com.vulpeus.kyoyu.net.KyoyuPacketPayload;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+@Mixin(ClientboundCustomPayloadPacket.class)
+public class ClientboundCustomPayloadPacketMixin {
+    @Inject(method = "readPayload", at = @At("HEAD"), cancellable = true)
+    private static void onReadPayload(ResourceLocation resourceLocation, FriendlyByteBuf friendlyByteBuf, CallbackInfoReturnable<CustomPacketPayload> cir) {
+        if (resourceLocation.equals(KyoyuPacketPayload.identifier)) {
+            cir.setReturnValue(new KyoyuPacketPayload(friendlyByteBuf));
+        }
+    }
+}
+*/
+//?}

--- a/src/main/java/com/vulpeus/kyoyu/mixins/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/com/vulpeus/kyoyu/mixins/ServerGamePacketListenerImplMixin.java
@@ -30,7 +30,7 @@ import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 //?}
 
 @Mixin(
-        //? if >=1.20.2 <1.20.5 {
+        //? if >=1.20.2 <=1.20.4 {
             /* net.minecraft.server.network.ServerCommonPacketListenerImpl.class */
         //?} else {
             net.minecraft.server.network.ServerGamePacketListenerImpl.class

--- a/src/main/java/com/vulpeus/kyoyu/mixins/ServerboundCustomPayloadPacketMixin.java
+++ b/src/main/java/com/vulpeus/kyoyu/mixins/ServerboundCustomPayloadPacketMixin.java
@@ -1,0 +1,26 @@
+package com.vulpeus.kyoyu.mixins;
+
+//? if FABRIC && >=1.20.2 <1.20.5 {
+/*
+import com.vulpeus.kyoyu.Kyoyu;
+import com.vulpeus.kyoyu.net.KyoyuPacketPayload;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerboundCustomPayloadPacket.class)
+public class ServerboundCustomPayloadPacketMixin {
+    @Inject(method = "readPayload", at = @At("HEAD"), cancellable = true)
+    private static void onReadPayload(ResourceLocation resourceLocation, FriendlyByteBuf friendlyByteBuf, CallbackInfoReturnable<CustomPacketPayload> cir) {
+        if (resourceLocation.equals(KyoyuPacketPayload.identifier)) {
+            cir.setReturnValue(new KyoyuPacketPayload(friendlyByteBuf));
+        }
+    }
+}
+*/
+//?}

--- a/src/main/java/com/vulpeus/kyoyu/mixins/ServerboundCustomPayloadPacketMixin.java
+++ b/src/main/java/com/vulpeus/kyoyu/mixins/ServerboundCustomPayloadPacketMixin.java
@@ -1,6 +1,6 @@
 package com.vulpeus.kyoyu.mixins;
 
-//? if FABRIC && >=1.20.2 <1.20.5 {
+//? if !PAPER && >=1.20.2 <=1.20.4 {
 /*
 import com.vulpeus.kyoyu.Kyoyu;
 import com.vulpeus.kyoyu.net.KyoyuPacketPayload;

--- a/src/main/java/com/vulpeus/kyoyu/net/KyoyuPacketPayload.java
+++ b/src/main/java/com/vulpeus/kyoyu/net/KyoyuPacketPayload.java
@@ -4,29 +4,24 @@ import com.vulpeus.kyoyu.CompatibleUtils;
 import com.vulpeus.kyoyu.Kyoyu;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
+import net.minecraft.network.FriendlyByteBuf;
 
 //? if >=1.20.2 {
     import net.minecraft.network.protocol.common.ClientboundCustomPayloadPacket;
     import net.minecraft.network.protocol.common.ServerboundCustomPayloadPacket;
+    import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
 //?} else {
     /*
     import net.minecraft.network.protocol.game.ClientboundCustomPayloadPacket;
     import net.minecraft.network.protocol.game.ServerboundCustomPayloadPacket;
+    import io.netty.buffer.Unpooled;
     */
-//?}
-
-//? if >=1.20.2 {
-    import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
-//?} else {
-    /* import io.netty.buffer.Unpooled; */
 //?}
 
 //? if >=1.20.6 {
     import net.minecraft.network.codec.ByteBufCodecs;
     import net.minecraft.network.codec.StreamCodec;
     import net.minecraft.network.RegistryFriendlyByteBuf;
-//?} else {
-    /* import net.minecraft.network.FriendlyByteBuf; */
 //?}
 
 
@@ -43,6 +38,11 @@ public class KyoyuPacketPayload
     public KyoyuPacketPayload(byte[] content) {
         this.content = content;
     }
+
+    public KyoyuPacketPayload(FriendlyByteBuf input) {
+        this(input.readByteArray());
+    }
+
     public byte[] content() {
         return this.content;
     }
@@ -59,18 +59,21 @@ public class KyoyuPacketPayload
         public @NotNull Type<? extends CustomPacketPayload> type() {
             return TYPE;
         }
-    //?} elif >=1.20.2 {
-        /*
-        @Override
-        public ResourceLocation id() {
-            return identifier;
-        }
-        @Override
-        public void write(FriendlyByteBuf packetbb) {
-            this.content = packetbb.readByteArray();
-        }
-        */
     //?}
+
+    //? if >=1.20.2 <1.20.5 {
+    /* @Override */
+    //?}
+    public ResourceLocation id() {
+        return identifier;
+    }
+
+    //? if >=1.20.2 <1.20.5 {
+    /* @Override */
+    //?}
+    public void write(FriendlyByteBuf output) {
+        output.writeByteArray(content);
+    }
 
     public static void register() {
         //? if FABRIC && >=1.20.6 {
@@ -86,7 +89,7 @@ public class KyoyuPacketPayload
             //?} else {
             /*
                 FriendlyByteBuf packetbb = new FriendlyByteBuf(Unpooled.buffer());
-                packetbb.writeByteArray(this.content);
+                write(packetbb);
                 Minecraft.getInstance().getConnection().send(new ServerboundCustomPayloadPacket(identifier, packetbb));
             */
             //?}
@@ -99,7 +102,7 @@ public class KyoyuPacketPayload
             //?} else {
             /*
                 FriendlyByteBuf packetbb = new FriendlyByteBuf(Unpooled.buffer());
-                packetbb.writeByteArray(this.content);
+                write(packetbb);
                 player.player().connection.send(new ClientboundCustomPayloadPacket(identifier, packetbb));
             */
             //?}

--- a/src/main/java/com/vulpeus/kyoyu/net/KyoyuPacketPayload.java
+++ b/src/main/java/com/vulpeus/kyoyu/net/KyoyuPacketPayload.java
@@ -61,16 +61,14 @@ public class KyoyuPacketPayload
         }
     //?}
 
-    //? if >=1.20.2 <1.20.5 {
+    //? if >=1.20.2 <=1.20.4
     /* @Override */
-    //?}
     public ResourceLocation id() {
         return identifier;
     }
 
-    //? if >=1.20.2 <1.20.5 {
+    //? if >=1.20.2 <=1.20.4
     /* @Override */
-    //?}
     public void write(FriendlyByteBuf output) {
         output.writeByteArray(content);
     }

--- a/src/main/resources/kyoyu.client.mixins.json
+++ b/src/main/resources/kyoyu.client.mixins.json
@@ -4,7 +4,7 @@
   "package": "com.vulpeus.kyoyu.client.mixins",
   "compatibilityLevel": "${java_compatibility_level}",
   "client": [
-    //? FABRIC && >=1.20.2 <1.20.5
+    //? >=1.20.2 <=1.20.4
     "ClientboundCustomPayloadPacketMixin",
     "ClientCommonPacketListenerImplMixin",
     "ClientPacketListenerMixin",

--- a/src/main/resources/kyoyu.client.mixins.json
+++ b/src/main/resources/kyoyu.client.mixins.json
@@ -4,6 +4,8 @@
   "package": "com.vulpeus.kyoyu.client.mixins",
   "compatibilityLevel": "${java_compatibility_level}",
   "client": [
+    //? FABRIC && >=1.20.2 <1.20.5
+    "ClientboundCustomPayloadPacketMixin",
     "ClientCommonPacketListenerImplMixin",
     "ClientPacketListenerMixin",
     "ConnectionMixin",

--- a/src/main/resources/kyoyu.mixins.json
+++ b/src/main/resources/kyoyu.mixins.json
@@ -6,6 +6,8 @@
   "mixins": [
     //? <=1.16.5
     "ServerboundCustomPayloadPacketIMixin",
+    //? FABRIC && >=1.20.2 <1.20.5
+    "ServerboundCustomPayloadPacketMixin",
     "PlayerListMixin",
     "ServerGamePacketListenerImplMixin"
   ],

--- a/src/main/resources/kyoyu.mixins.json
+++ b/src/main/resources/kyoyu.mixins.json
@@ -6,7 +6,7 @@
   "mixins": [
     //? <=1.16.5
     "ServerboundCustomPayloadPacketIMixin",
-    //? FABRIC && >=1.20.2 <1.20.5
+    //? >=1.20.2 <=1.20.4
     "ServerboundCustomPayloadPacketMixin",
     "PlayerListMixin",
     "ServerGamePacketListenerImplMixin"


### PR DESCRIPTION
- `DiscardedPayload`が生成されないように`ServerboundCustomPayloadPacketMixin`と`ClientboundCustomPayloadPacketMixin`を追加
- `KyoyuPacketPayload.write()`がwriteではなくreadをしていたため`io.netty.handler.codec.DecoderException`が発生していたのを修正